### PR TITLE
Add management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This project contains a simple Telegram bot for selling products with manual pay
 - Admin approves purchases and credentials are sent to the buyer.
 - Buyers can obtain a current authenticator code with `/code <product_id>`.
 - Admin can list and manage buyers.
+- Admin can edit product fields with `/editproduct` and resend credentials with
+  `/resend`.
+- Stats for each product available via `/stats`.
 
 ## Setup
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- extend README with new admin commands
- support editing products via `/editproduct`
- allow credentials to be resent to buyers with `/resend`
- display stats for products with `/stats`
- register the new command handlers

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686fbd1779e0832d8a96e4932e299231