### PR TITLE
Fix admin placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ This project contains a simple Telegram bot for selling products with manual pay
    ```bash
    pip install -r requirements.txt
    ```
-2. Create `data.json` (already included). Set the following environment variables or rely on the defaults in `bot.py`:
+2. Create `data.json` (already included). Set the following environment variables **before** running the bot:
    - `ADMIN_ID` – Telegram user ID of the admin
    - `ADMIN_PHONE` – phone number shown when users run `/contact`
+   
+   `bot.py` does not provide real defaults for these values, so you must set them explicitly.
 3. Run the bot with your bot token:
    ```bash
    python bot.py <TOKEN>

--- a/bot.py
+++ b/bot.py
@@ -9,8 +9,8 @@ from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandl
 import pyotp
 
 DATA_FILE = Path('data.json')
-ADMIN_ID = int(os.getenv("ADMIN_ID", "123456789"))  # replace with your Telegram user id
-ADMIN_PHONE = os.getenv("ADMIN_PHONE", "+989152062041")  # manager contact number
+ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))  # Telegram user id of the admin
+ADMIN_PHONE = os.getenv("ADMIN_PHONE", "")  # manager contact number
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
## Summary
- use placeholder values for `ADMIN_ID` and `ADMIN_PHONE`
- clarify in README that these variables need to be set before running the bot

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712edf6324832db56542c0275221be