### PR TITLE
Add cancel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ from a provided secret.
 - **User commands**
   - `/listproducts` – list available products
   - `/buy <product>` – start a purchase and send payment screenshot
+  - `/cancel` – cancel a pending purchase
   - `/getcode` – retrieve the current TOTP code
 
 Product and purchase data are stored in `data.json` in the repository

--- a/bot.py
+++ b/bot.py
@@ -100,6 +100,17 @@ async def buy(update: Update, context: ContextTypes.DEFAULT_TYPE):
     save_data()
 
 
+async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    user_id = str(update.effective_user.id)
+    purchase = DATA["purchases"].get(user_id)
+    if not purchase or purchase.get("status") != "pending":
+        await update.message.reply_text("No pending purchase found")
+        return
+    purchase["status"] = "cancelled"
+    save_data()
+    await update.message.reply_text("Purchase cancelled")
+
+
 @admin_required
 async def confirm(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if len(context.args) < 4:
@@ -191,6 +202,7 @@ if __name__ == "__main__":
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("listproducts", listproducts))
     application.add_handler(CommandHandler("buy", buy))
+    application.add_handler(CommandHandler("cancel", cancel))
     application.add_handler(CommandHandler("getcode", getcode))
 
     application.add_handler(CommandHandler("addproduct", addproduct))


### PR DESCRIPTION
## Summary
- allow users to cancel a pending purchase
- document the new `/cancel` command in the README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68714b698788832dbd893c34a406d832